### PR TITLE
Fix overlay alignment and reset points when swapping images

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,14 +220,28 @@ canvas { display: block; width: 100%; height: auto; }
     const sr = Math.sin(r);
     const dx = manualAdjust.offsetX;
     const dy = manualAdjust.offsetY;
-    return {
-      a: s * (cr * base.a - sr * base.b),
-      b: s * (sr * base.a + cr * base.b),
-      c: -s * (cr * base.b + sr * base.a),
-      d: s * (cr * base.a - sr * base.b),
-      e: s * (cr * base.tx - sr * base.ty) + dx,
-      f: s * (sr * base.tx + cr * base.ty) + dy
-    };
+    const baseA = base.a;
+    const baseB = base.b;
+    const baseC = -base.b;
+    const baseD = base.a;
+    const baseE = base.tx;
+    const baseF = base.ty;
+
+    const m00 = s * cr;
+    const m01 = -s * sr;
+    const m02 = dx;
+    const m10 = s * sr;
+    const m11 = s * cr;
+    const m12 = dy;
+
+    const outA = m00 * baseA + m01 * baseB;
+    const outB = m10 * baseA + m11 * baseB;
+    const outC = m00 * baseC + m01 * baseD;
+    const outD = m10 * baseC + m11 * baseD;
+    const outE = m00 * baseE + m01 * baseF + m02;
+    const outF = m10 * baseE + m11 * baseF + m12;
+
+    return { a: outA, b: outB, c: outC, d: outD, e: outE, f: outF };
   }
 
   function clamp(v,min,max){ return Math.max(min, Math.min(max, v)); }
@@ -423,6 +437,7 @@ canvas { display: block; width: 100%; height: auto; }
 
   function drawOnce(){
     fitCanvas();
+    ctx.setTransform(1,0,0,1,0,0);
     ctx.clearRect(0,0,canvas.width,canvas.height);
     const dimsB = naturalSize('B');
     updateMatchedView();

--- a/manual.html
+++ b/manual.html
@@ -95,6 +95,7 @@ th { background: #f7f7f7; }
   <select id="cp1"></select>
   <select id="cp2"></select>
   <select id="cp3"></select>
+  <button id="alignNowBtn" type="button">Align viewfinders with current landmarks</button>
   <button id="exportReportBtn">Export Report</button>
   <span class="small muted">Hotkey: <b>L</b> cycles label mode</span>
 </div>
@@ -331,7 +332,8 @@ th { background: #f7f7f7; }
   const ctxA=canA.getContext('2d'), ctxB=canB.getContext('2d');
   const selCurrent=$('selCurrent'), selSwatch=$('selSwatch'), selName=$('selName'), selDropdown=$('selDropdown');
   const anchorSel=$('anchorSel'), cp1=$('cp1'), cp2=$('cp2'), cp3=$('cp3');
-  const alignChk=$('alignChk'); 
+  const alignChk=$('alignChk');
+  const alignNowBtn=$('alignNowBtn');
   const symChk   = $('symChk');
   const casLabelModeSel=$('casLabelMode');
   const diffBody = $('diffTable').querySelector('tbody');
@@ -352,6 +354,7 @@ th { background: #f7f7f7; }
   let lastImgBDataURL = null;
   let currentViewA = null;
   let currentViewB = null;
+  let manualAlignActive = false;
   const storageAvailable = (()=>{
     try {
       const k='__fg_test__';
@@ -477,8 +480,13 @@ th { background: #f7f7f7; }
 
   function updateMatchedView(){
     const shared = LANDMARKS.map(l=>l.id).filter(id=>pointsA[id] && pointsB[id]);
-    if(shared.length < 3){
+    const allPlaced = shared.length === LANDMARKS.length;
+    const shouldAlign = manualAlignActive || allPlaced;
+    if(!shouldAlign || shared.length < 3){
       currentViewA = currentViewB = null;
+      if(!allPlaced){
+        manualAlignActive = manualAlignActive && shared.length >= 3;
+      }
       return;
     }
     const dimsA = naturalSize('A');
@@ -501,6 +509,12 @@ th { background: #f7f7f7; }
     }
     currentViewA = alignBox(boxA, targetW, targetH, dimsA);
     currentViewB = alignBox(boxB, targetW, targetH, dimsB);
+  }
+
+  function resetAlignment(){
+    manualAlignActive = false;
+    currentViewA = null;
+    currentViewB = null;
   }
 
   function renderSpace(which){
@@ -932,8 +946,12 @@ th { background: #f7f7f7; }
     const f=e.target.files[0]; if(!f) return;
     const reader = new FileReader();
     reader.onload = ()=>{
+      pointsA = {};
+      resetAlignment();
       lastImgADataURL = reader.result;
       imgA.src = reader.result;
+      refreshAll();
+      persistSharedState();
     };
     reader.readAsDataURL(f);
   });
@@ -942,8 +960,12 @@ th { background: #f7f7f7; }
     stopLiveCapture();
     const reader = new FileReader();
     reader.onload = ()=>{
+      pointsB = {};
+      resetAlignment();
       lastImgBDataURL = reader.result;
       imgB.src = reader.result;
+      refreshAll();
+      persistSharedState();
     };
     reader.readAsDataURL(f);
   });
@@ -982,12 +1004,17 @@ th { background: #f7f7f7; }
     const blob = new Blob([html],{type:'text/html'});
     const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='faceguide_report.html'; a.click();
   }
-  $('resetA').addEventListener('click', ()=>{ pointsA={}; redraw('A'); refreshDiff(); refreshProgress(); persistSharedState(); });
-  $('resetB').addEventListener('click', ()=>{ stopLiveCapture(); pointsB={}; redraw('B'); refreshDiff(); refreshProgress(); persistSharedState(); });
+  $('resetA').addEventListener('click', ()=>{ pointsA={}; resetAlignment(); redraw('A'); refreshDiff(); refreshProgress(); persistSharedState(); });
+  $('resetB').addEventListener('click', ()=>{ stopLiveCapture(); pointsB={}; resetAlignment(); redraw('B'); refreshDiff(); refreshProgress(); persistSharedState(); });
   $('saveA').addEventListener('click', ()=> downloadJSON({points:pointsA}, 'landmarks_A.json'));
   $('saveB').addEventListener('click', ()=> downloadJSON({points:pointsB}, 'landmarks_B.json'));
-  $('loadA').addEventListener('click', ()=> pickJSON(obj=>{ if(obj?.points){ pointsA=obj.points; redraw('A'); refreshDiff(); refreshProgress(); persistSharedState(); } }));
-  $('loadB').addEventListener('click', ()=> pickJSON(obj=>{ if(obj?.points){ stopLiveCapture(); pointsB=obj.points; redraw('B'); refreshDiff(); refreshProgress(); persistSharedState(); } }));
+  $('loadA').addEventListener('click', ()=> pickJSON(obj=>{ if(obj?.points){ pointsA=obj.points; resetAlignment(); redraw('A'); refreshDiff(); refreshProgress(); persistSharedState(); } }));
+  $('loadB').addEventListener('click', ()=> pickJSON(obj=>{ if(obj?.points){ stopLiveCapture(); pointsB=obj.points; resetAlignment(); redraw('B'); refreshDiff(); refreshProgress(); persistSharedState(); } }));
+
+  alignNowBtn.addEventListener('click', ()=>{
+    manualAlignActive = true;
+    refreshAll();
+  });
   function downloadJSON(obj, filename){
     const blob = new Blob([JSON.stringify(obj,null,2)],{type:'application/json'});
     const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download=filename; a.click();


### PR DESCRIPTION
## Summary
- clear stored manual landmarks when new reference or comparison images are loaded so view alignment stays disabled until all new points are placed
- recompute the overlay transform correctly and reset the canvas matrix so the target image properly overlays the live capture feed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8789d68a883268374d6711baf642b