### PR TITLE
Improve overlay persistence and add tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/index.html
+++ b/index.html
@@ -128,6 +128,8 @@ canvas { display: block; width: 100%; height: auto; }
   let pointsB = {};
   let controlIds = ['left_pupil','right_pupil','nose_tip'];
   let stateLoaded = false;
+  let storageTruncated = false;
+  let pendingImages = false;
   const manualDefaults = {offsetX:0, offsetY:0, scale:1, rotation:0};
   const manualAdjust = {...manualDefaults};
 
@@ -417,6 +419,11 @@ canvas { display: block; width: 100%; height: auto; }
       return;
     }
     const parts = [];
+    if(pendingImages){
+      parts.push('Saved images are still being prepared. Refresh in a moment after returning from the Manual Landmark Setup page.');
+    } else if(storageTruncated){
+      parts.push('Stored images were too large to keep. Re-upload smaller versions on the Manual Landmark Setup page so the overlay can display them.');
+    }
     if(!refReady){ parts.push('Waiting for target image to load.'); }
     if(!baseAvailable){
       parts.push(captureState.active ? 'Waiting for live capture...' : 'No comparison image detected. Start a capture or freeze a frame in the main tool.');
@@ -567,6 +574,10 @@ canvas { display: block; width: 100%; height: auto; }
   }
 
   function loadState(){
+    pendingImages = false;
+    storageTruncated = false;
+    refReady = false;
+    baseReady = false;
     try {
       const raw = window.localStorage.getItem(STATE_KEY);
       if(!raw){
@@ -579,6 +590,8 @@ canvas { display: block; width: 100%; height: auto; }
       pointsB = data.pointsB || {};
       const cp = data.controlPoints || {};
       if(cp.cp1 && cp.cp2 && cp.cp3){ controlIds = [cp.cp1, cp.cp2, cp.cp3]; }
+      pendingImages = !!data.pendingImages;
+      storageTruncated = !!data.truncated;
       if(data.imgA){ refImg.src = data.imgA; } else { statusEl.textContent = 'Target image missing. Upload it on the main page.'; }
       if(data.imgB){ baseImg.src = data.imgB; baseReady = true; }
       stateLoaded = true;

--- a/manual.html
+++ b/manual.html
@@ -11,6 +11,8 @@ body { margin: 16px; color: var(--fg); background: var(--bg); font-family: syste
 h1 { font-size: 1.25rem; margin: 0 0 8px; }
 .muted { color: var(--muted); }
 .small { font-size: 12px; }
+.status-message { display:none; margin-top:8px; padding:8px 10px; border-radius:8px; border:1px solid #ffd2d2; background:#fff5f5; color:#9a1e1e; font-size:12px; }
+.status-message.show { display:block; }
 
 header { margin-bottom: 10px; }
 .panel { border: 1px solid var(--line); border-radius: 8px; padding: 12px; margin-top: 12px; }
@@ -69,6 +71,7 @@ th { background: #f7f7f7; }
   <h1>FaceGuide — Manual Landmark Comparator</h1>
   <p class="muted">Place and compare landmarks manually across the reference and capture images.</p>
   <p><a href="index.html">← Back to overlay alignment view</a></p>
+  <div id="storageStatus" class="status-message" role="status" aria-live="polite"></div>
 </header>
 
 <section class="panel selector">
@@ -342,6 +345,7 @@ th { background: #f7f7f7; }
   const activeDesc=$('activeDesc');
   const startCaptureBtn=$('startCapture'), stopCaptureBtn=$('stopCapture'), freezeCaptureBtn=$('freezeCapture');
   const captureVideo=$('captureVideo');
+  const storageStatusEl = $('storageStatus');
 
   // --------- State ---------
   let imgA = new Image(), imgB = new Image();
@@ -352,9 +356,15 @@ th { background: #f7f7f7; }
   const SHARED_STATE_KEY = 'faceguide_overlay_state_v1';
   let lastImgADataURL = null;
   let lastImgBDataURL = null;
+  let storedImgADataURL = null;
+  let storedImgBDataURL = null;
+  let preparingImgA = false;
+  let preparingImgB = false;
   let currentViewA = null;
   let currentViewB = null;
   let manualAlignActive = false;
+  const MAX_STORED_EDGE = 1600;
+  const STORED_IMAGE_QUALITY = 0.9;
   const storageAvailable = (()=>{
     try {
       const k='__fg_test__';
@@ -375,6 +385,103 @@ th { background: #f7f7f7; }
   imgB.addEventListener('load', ()=>{ redraw('B'); refreshDiff(); refreshProgress(); persistSharedState(); });
 
   // --------- Utils ---------
+  function updateStorageNotice(msg){
+    if(!storageStatusEl) return;
+    if(msg){
+      storageStatusEl.textContent = msg;
+      storageStatusEl.classList.add('show');
+    } else {
+      storageStatusEl.textContent = '';
+      storageStatusEl.classList.remove('show');
+    }
+  }
+
+  function isQuotaError(err){
+    if(!err) return false;
+    const code = err && err.code;
+    return err.name === 'QuotaExceededError' || err.name === 'NS_ERROR_DOM_QUOTA_REACHED' || code === 22 || code === 1014;
+  }
+
+  function createStorageFriendlyDataURL(dataUrl){
+    return new Promise(resolve=>{
+      if(!dataUrl){ resolve(null); return; }
+      const img = new Image();
+      img.onload = ()=>{
+        try {
+          let {width, height} = img;
+          if(!width || !height){ resolve(dataUrl); return; }
+          const longest = Math.max(width, height);
+          let targetW = width;
+          let targetH = height;
+          if(longest > MAX_STORED_EDGE){
+            const scale = MAX_STORED_EDGE / longest;
+            targetW = Math.max(1, Math.round(width * scale));
+            targetH = Math.max(1, Math.round(height * scale));
+          }
+          const canvas = document.createElement('canvas');
+          canvas.width = targetW;
+          canvas.height = targetH;
+          const ctx = canvas.getContext('2d');
+          ctx.drawImage(img, 0, 0, targetW, targetH);
+          let chosen = dataUrl;
+          try {
+            const jpeg = canvas.toDataURL('image/jpeg', STORED_IMAGE_QUALITY);
+            if(jpeg && (!dataUrl.startsWith('data:image/jpeg') || jpeg.length <= dataUrl.length)){
+              chosen = jpeg;
+            } else if(targetW !== width || targetH !== height) {
+              const scaled = canvas.toDataURL();
+              if(scaled && scaled.length < dataUrl.length){
+                chosen = scaled;
+              }
+            }
+          } catch(inner){
+            console.warn('JPEG conversion failed, keeping original data URL', inner);
+          }
+          resolve(chosen || dataUrl);
+        } catch(err){
+          console.warn('Failed to optimise image for storage', err);
+          resolve(dataUrl);
+        }
+      };
+      img.onerror = ()=> resolve(dataUrl);
+      img.src = dataUrl;
+    });
+  }
+
+  function scheduleStorageImage(which, dataUrl){
+    if(which==='A'){
+      preparingImgA = !!dataUrl;
+      if(!dataUrl){ storedImgADataURL = null; }
+    } else {
+      preparingImgB = !!dataUrl;
+      if(!dataUrl){ storedImgBDataURL = null; }
+    }
+    if(!dataUrl){
+      persistSharedState();
+      return;
+    }
+    createStorageFriendlyDataURL(dataUrl).then(result=>{
+      if(which==='A'){
+        storedImgADataURL = result;
+        preparingImgA = false;
+      } else {
+        storedImgBDataURL = result;
+        preparingImgB = false;
+      }
+      persistSharedState();
+    }).catch(err=>{
+      console.warn('Failed to prepare image for storage', err);
+      if(which==='A'){
+        storedImgADataURL = dataUrl;
+        preparingImgA = false;
+      } else {
+        storedImgBDataURL = dataUrl;
+        preparingImgB = false;
+      }
+      persistSharedState();
+    });
+  }
+
   function clamp(v,min,max){ return Math.max(min, Math.min(max, v)); }
   function dist(a,b){ if(!a||!b) return null; const dx=a.x-b.x, dy=a.y-b.y; return Math.hypot(dx,dy); }
   function vDist(a,b){ if(!a||!b) return null; return Math.abs(a.y-b.y); }
@@ -530,17 +637,44 @@ th { background: #f7f7f7; }
 
   function persistSharedState(){
     if(!storageAvailable) return;
+    const basePayload = {
+      pointsA: clonePoints(pointsA),
+      pointsB: clonePoints(pointsB),
+      controlPoints: { cp1: cp1.value, cp2: cp2.value, cp3: cp3.value }
+    };
+    const payload = {
+      ...basePayload,
+      imgA: preparingImgA ? null : (storedImgADataURL ?? null),
+      imgB: preparingImgB ? null : (storedImgBDataURL ?? null),
+      truncated: false,
+      pendingImages: preparingImgA || preparingImgB
+    };
     try {
-      const payload = {
-        pointsA: clonePoints(pointsA),
-        pointsB: clonePoints(pointsB),
-        imgA: lastImgADataURL || null,
-        imgB: lastImgBDataURL || null,
-        controlPoints: { cp1: cp1.value, cp2: cp2.value, cp3: cp3.value }
-      };
       window.localStorage.setItem(SHARED_STATE_KEY, JSON.stringify(payload));
+      if(!(preparingImgA || preparingImgB)){
+        updateStorageNotice('');
+      }
     } catch (err) {
       console.warn('Persist overlay state failed', err);
+      if(isQuotaError(err)){
+        const fallback = {
+          ...basePayload,
+          imgA: null,
+          imgB: null,
+          truncated: true,
+          pendingImages: false
+        };
+        try {
+          window.localStorage.setItem(SHARED_STATE_KEY, JSON.stringify(fallback));
+        } catch (inner) {
+          console.warn('Fallback persist overlay state failed', inner);
+        }
+        storedImgADataURL = null;
+        storedImgBDataURL = null;
+        preparingImgA = false;
+        preparingImgB = false;
+        updateStorageNotice('Images were too large to store for the overlay view. Please upload smaller versions so the overlay page can load them.');
+      }
     }
   }
 
@@ -561,11 +695,26 @@ th { background: #f7f7f7; }
       }
       if(data.imgA){
         lastImgADataURL = data.imgA;
+        storedImgADataURL = data.imgA;
         imgA.src = data.imgA;
+      } else {
+        lastImgADataURL = null;
+        storedImgADataURL = null;
       }
       if(data.imgB){
         lastImgBDataURL = data.imgB;
+        storedImgBDataURL = data.imgB;
         imgB.src = data.imgB;
+      } else {
+        lastImgBDataURL = null;
+        storedImgBDataURL = null;
+      }
+      preparingImgA = false;
+      preparingImgB = false;
+      if(data.truncated){
+        updateStorageNotice('Previously saved images were trimmed because they exceeded browser storage limits. Re-upload smaller files so the overlay can show them.');
+      } else {
+        updateStorageNotice('');
       }
     } catch (err) {
       console.warn('Failed to load overlay state', err);
@@ -930,6 +1079,7 @@ th { background: #f7f7f7; }
       if(dataUrl){
         lastImgBDataURL = dataUrl;
         imgB.src = dataUrl;
+        scheduleStorageImage('B', dataUrl);
       }
     } catch (e) {
       console.error('Freeze frame failed', e);
@@ -950,6 +1100,7 @@ th { background: #f7f7f7; }
       resetAlignment();
       lastImgADataURL = reader.result;
       imgA.src = reader.result;
+      scheduleStorageImage('A', reader.result);
       refreshAll();
       persistSharedState();
     };
@@ -964,6 +1115,7 @@ th { background: #f7f7f7; }
       resetAlignment();
       lastImgBDataURL = reader.result;
       imgB.src = reader.result;
+      scheduleStorageImage('B', reader.result);
       refreshAll();
       persistSharedState();
     };
@@ -975,7 +1127,17 @@ th { background: #f7f7f7; }
     const r = canvas.getBoundingClientRect();
     const x = evt.clientX - r.left, y = evt.clientY - r.top;
     const w = canvas.width || 1, h = canvas.height || 1;
-    const pt = {u: clamp(x/w,0,1), v: clamp(y/h,0,1)};
+    const dims = naturalSize(which);
+    const view = which==='A' ? currentViewA : currentViewB;
+    let u = clamp(x/w,0,1);
+    let v = clamp(y/h,0,1);
+    if(view){
+      const nx = view.x + u * (view.w || 0);
+      const ny = view.y + v * (view.h || 0);
+      u = clamp(nx / (dims.w || 1), 0, 1);
+      v = clamp(ny / (dims.h || 1), 0, 1);
+    }
+    const pt = {u, v};
     if(which==='A') pointsA[activeId]=pt; else pointsB[activeId]=pt;
     redraw(which); refreshDiff(); refreshProgress();
     persistSharedState();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "faceguide",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "faceguide",
+      "version": "0.1.0",
+      "devDependencies": {}
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "faceguide",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node scripts/dev-server.mjs",
+    "build": "node scripts/build.mjs",
+    "preview": "node scripts/dev-server.mjs --dir dist --port 4173",
+    "lint": "node scripts/check-html.mjs",
+    "test": "npm run lint"
+  },
+  "devDependencies": {}
+}

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,39 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const sourceDir = path.resolve(__dirname, '..');
+const outDir = path.resolve(__dirname, '..', 'dist');
+
+async function copyDir(src, dest) {
+  await fs.mkdir(dest, { recursive: true });
+  const entries = await fs.readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      if (['node_modules', 'dist', '.git', 'scripts'].includes(entry.name)) {
+        continue;
+      }
+      await copyDir(srcPath, destPath);
+    } else if (entry.isFile()) {
+      if (['package.json', 'package-lock.json', '.gitignore'].includes(entry.name)) {
+        continue;
+      }
+      await fs.copyFile(srcPath, destPath);
+    }
+  }
+}
+
+async function main() {
+  await fs.rm(outDir, { recursive: true, force: true });
+  await copyDir(sourceDir, outDir);
+  console.log(`Copied static files from ${sourceDir} to ${outDir}`);
+}
+
+main().catch(err => {
+  console.error('Build failed:', err);
+  process.exitCode = 1;
+});

--- a/scripts/check-html.mjs
+++ b/scripts/check-html.mjs
@@ -1,0 +1,78 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectDir = path.resolve(__dirname, '..');
+
+async function collectHtmlFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (['node_modules', 'dist', '.git', 'scripts'].includes(entry.name)) {
+        continue;
+      }
+      files.push(...await collectHtmlFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function relativeToProject(filePath) {
+  return path.relative(path.resolve(__dirname, '..'), filePath);
+}
+
+async function main() {
+  const htmlFiles = await collectHtmlFiles(projectDir);
+  if (htmlFiles.length === 0) {
+    console.error('No HTML files found to validate.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const errors = [];
+  const requiredSnippets = new Map([
+    ['index.html', ['id="overlayCanvas"', 'pendingImages']],
+    ['manual.html', ['scheduleStorageImage', 'storageStatus']]
+  ]);
+
+  for (const file of htmlFiles) {
+    const contents = await fs.readFile(file, 'utf8');
+    const relPath = relativeToProject(file);
+
+    if (!/<!DOCTYPE html>/i.test(contents)) {
+      errors.push(`${relPath}: missing <!DOCTYPE html>`);
+    }
+    if (!contents.toLowerCase().includes('</html>')) {
+      errors.push(`${relPath}: missing closing </html> tag`);
+    }
+
+    const fileName = path.basename(file);
+    const snippets = requiredSnippets.get(fileName);
+    if (snippets) {
+      for (const snippet of snippets) {
+        if (!contents.includes(snippet)) {
+          errors.push(`${relPath}: expected to contain "${snippet}"`);
+        }
+      }
+    }
+  }
+
+  if (errors.length) {
+    console.error('HTML checks failed:\n' + errors.map(err => ` - ${err}`).join('\n'));
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Validated ${htmlFiles.length} HTML file(s).`);
+}
+
+main().catch(err => {
+  console.error('HTML check failed with error:', err);
+  process.exitCode = 1;
+});

--- a/scripts/dev-server.mjs
+++ b/scripts/dev-server.mjs
@@ -1,0 +1,85 @@
+import http from 'http';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const args = process.argv.slice(2);
+let rootDir = path.resolve(__dirname, '..');
+let port = 5173;
+
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
+  if (arg === '--dir' && args[i + 1]) {
+    rootDir = path.resolve(__dirname, '..', args[i + 1]);
+    i += 1;
+  } else if (arg === '--port' && args[i + 1]) {
+    port = Number(args[i + 1]) || port;
+    i += 1;
+  }
+}
+
+function mimeType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case '.html':
+      return 'text/html; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.js':
+      return 'text/javascript; charset=utf-8';
+    case '.json':
+      return 'application/json; charset=utf-8';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.svg':
+      return 'image/svg+xml';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  if (!req.url) {
+    res.writeHead(400).end('Bad request');
+    return;
+  }
+  const requestUrl = new URL(req.url, `http://${req.headers.host}`);
+  let pathname = decodeURIComponent(requestUrl.pathname);
+  if (pathname.endsWith('/')) {
+    pathname += 'index.html';
+  }
+  const filePath = path.join(rootDir, pathname);
+  if (!filePath.startsWith(rootDir)) {
+    res.writeHead(403).end('Forbidden');
+    return;
+  }
+  try {
+    const stats = await fs.stat(filePath);
+    if (stats.isDirectory()) {
+      const indexPath = path.join(filePath, 'index.html');
+      const indexContent = await fs.readFile(indexPath);
+      res.writeHead(200, { 'Content-Type': mimeType(indexPath) });
+      res.end(indexContent);
+      return;
+    }
+    const data = await fs.readFile(filePath);
+    res.writeHead(200, { 'Content-Type': mimeType(filePath) });
+    res.end(data);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      res.writeHead(404).end('Not found');
+    } else {
+      res.writeHead(500).end('Server error');
+    }
+  }
+});
+
+server.listen(port, () => {
+  console.log(`Serving ${rootDir} on http://localhost:${port}/`);
+});


### PR DESCRIPTION
## Summary
- compress and guard stored overlay images so manual uploads survive browser storage limits and show clear warnings in the manual workflow
- surface pending-image and storage-limit messaging on the overlay view so users know why the reference portrait is unavailable
- add npm metadata with lightweight build, dev-server, and HTML check scripts for running and validating the static site locally

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d87c8ace1c832693e67fe44575de4b